### PR TITLE
Delete sprocket by sku

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>guava</artifactId>
             <version>18.0</version>
         </dependency>
+        <dependency>
+        	<groupId>org.springframework.boot</groupId>
+        	<artifactId>spring-boot-starter-data-rest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,6 @@
             <artifactId>guava</artifactId>
             <version>18.0</version>
         </dependency>
-        <dependency>
-        	<groupId>org.springframework.boot</groupId>
-        	<artifactId>spring-boot-starter-data-rest</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/dev9/dataexample/controller/SprocketController.java
+++ b/src/main/java/com/dev9/dataexample/controller/SprocketController.java
@@ -4,14 +4,14 @@ package com.dev9.dataexample.controller;
 import com.dev9.dataexample.entity.Sprocket;
 import com.dev9.dataexample.repo.SprocketRepository;
 import com.google.common.collect.Lists;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,5 +43,14 @@ public class SprocketController {
     public Sprocket getSprocketBySku(@PathVariable("sku") String sku) {
         return sprocketRepository.findBySku(sku);
     }
-
+    
+    @RequestMapping(value = "/sprockets/sku/{sku}", method = {RequestMethod.DELETE})
+    public void deleteSprocketBySku(@PathVariable("sku") String sku) {
+    	Sprocket sprocket = sprocketRepository.findBySku(sku);
+    	if (sprocket == null) {
+    		throw new ResourceNotFoundException("SKU "  + sku + " not Found.");
+    	}
+    	long id = sprocket.getId();
+        sprocketRepository.delete(id);
+    }
 }

--- a/src/main/java/com/dev9/dataexample/controller/SprocketController.java
+++ b/src/main/java/com/dev9/dataexample/controller/SprocketController.java
@@ -6,7 +6,6 @@ import com.dev9.dataexample.repo.SprocketRepository;
 import com.google.common.collect.Lists;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,11 +45,6 @@ public class SprocketController {
     
     @RequestMapping(value = "/sprockets/sku/{sku}", method = {RequestMethod.DELETE})
     public void deleteSprocketBySku(@PathVariable("sku") String sku) {
-    	Sprocket sprocket = sprocketRepository.findBySku(sku);
-    	if (sprocket == null) {
-    		throw new ResourceNotFoundException("SKU "  + sku + " not Found.");
-    	}
-    	long id = sprocket.getId();
-        sprocketRepository.delete(id);
+    	sprocketRepository.deleteBySku(sku);
     }
 }

--- a/src/main/java/com/dev9/dataexample/entity/Sprocket.java
+++ b/src/main/java/com/dev9/dataexample/entity/Sprocket.java
@@ -22,6 +22,10 @@ public class Sprocket implements Serializable {
     private String sku;
 
     private String brand;
+    
+    public long getId() {
+    	return id;
+    }
 
     public String getDescription() {
         return description;

--- a/src/main/java/com/dev9/dataexample/entity/Sprocket.java
+++ b/src/main/java/com/dev9/dataexample/entity/Sprocket.java
@@ -23,10 +23,6 @@ public class Sprocket implements Serializable {
 
     private String brand;
     
-    public long getId() {
-    	return id;
-    }
-
     public String getDescription() {
         return description;
     }

--- a/src/main/java/com/dev9/dataexample/repo/SprocketRepository.java
+++ b/src/main/java/com/dev9/dataexample/repo/SprocketRepository.java
@@ -2,15 +2,19 @@ package com.dev9.dataexample.repo;
 
 
 import com.dev9.dataexample.entity.Sprocket;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Repository
+@Transactional
 public interface SprocketRepository extends CrudRepository<Sprocket, Long> {
 
     Sprocket findBySku(String sku);
     List<Sprocket> findByBrand(String brand);
-
+    
+    void deleteBySku(String sku);
 }


### PR DESCRIPTION
Added deletedBySku to the SprocketRepository.
By itself, just adding the extra API executed without error and WITHOUT deleting anything.
:(
In addition I had to add @Transactional to the SprocketRepository interface.
At first I hacked around with 
 @Modifying
 @Query("delete from Sprocket as m where m.sku = ?1")
To define explicitly what the delete should do. Once I got those two in place it complained of no transaction. Putting @Transactional on the class worked with all 3 annotations, but it turns out @Modifying and the @Query were not necessary.  It all work just fine with just the API call and the @Transactional.

Testing:  I inserted extra Sprockets, displayed them, deleted one... displayed again.  All appeared working.
